### PR TITLE
Fix README links for knowledges

### DIFF
--- a/AUDT/LOTE_1/Consolidados/Lote_1_2/README.md
+++ b/AUDT/LOTE_1/Consolidados/Lote_1_2/README.md
@@ -21,8 +21,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 ## Archivos clave
 - `master_plan_aingz_infrastructure.md`: Documento guía maestro para toda integración, versionado y auditoría.
 - `matrices/Matriz Precedencia Instrucciones Full Custom Infraestructura.md`: Matriz de jerarquía y features para todo el sistema.
-- `knowledge/Knowledge Base Matriz Precedencia Templates Universales Raw.md`: Núcleo de referencia y relación de precedencia, templates y posibilidades de input/output.
-- `templates/Templates Casos Uso Precedencia Infraestructura Full Custom.md`: Plantillas base para instanciar entornos y flujos.
+- `../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md`: Núcleo de referencia y relación de precedencia, templates y posibilidades de input/output.
 - `doc/Mapa Jerarquía Instrucciones - Aing Z Repo (visual + Markdown).md`: Visual de jerarquía y precedencia de instrucciones.
 
 ---
@@ -36,9 +35,8 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 
 ## Referencias
 - [master_plan_aingz_infrastructure.md](master_plan_aingz_infrastructure.md)
-- [knowledge/Knowledge Base Matriz Precedencia Templates Universales Raw.md](knowledge/Knowledge%20Base%20Matriz%20Precedencia%20Templates%20Universales%20Raw.md)
+- [../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md](../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md)
 - [matrices/Matriz Precedencia Instrucciones Full Custom Infraestructura.md](matrices/Matriz%20Precedencia%20Instrucciones%20Full%20Custom%20Infraestructura.md)
-- [templates/Templates Casos Uso Precedencia Infraestructura Full Custom.md](templates/Templates%20Casos%20Uso%20Precedencia%20Infraestructura%20Full%20Custom.md)
 - [doc/Mapa Jerarquía Instrucciones - Aing Z Repo (visual + Markdown).md](doc/Mapa%20Jerarqu%C3%ADa%20Instrucciones%20-%20Aing%20Z%20Repo%20(visual%20%2B%20Markdown).md)
 
 ---

--- a/AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md
+++ b/AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md
@@ -21,8 +21,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 ## Archivos clave
 - `master_plan_aingz_infrastructure.md`: Documento guía maestro para toda integración, versionado y auditoría.
 - `matrices/Matriz Precedencia Instrucciones Full Custom Infraestructura.md`: Matriz de jerarquía y features para todo el sistema.
-- `knowledge/Knowledge Base Matriz Precedencia Templates Universales Raw.md`: Núcleo de referencia y relación de precedencia, templates y posibilidades de input/output.
-- `templates/Templates Casos Uso Precedencia Infraestructura Full Custom.md`: Plantillas base para instanciar entornos y flujos.
+- `../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md`: Núcleo de referencia y relación de precedencia, templates y posibilidades de input/output.
 - `doc/Mapa Jerarquía Instrucciones - Aing Z Repo (visual + Markdown).md`: Visual de jerarquía y precedencia de instrucciones.
 
 ---
@@ -36,9 +35,8 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 
 ## Referencias
 - [master_plan_aingz_infrastructure.md](master_plan_aingz_infrastructure.md)
-- [knowledge/Knowledge Base Matriz Precedencia Templates Universales Raw.md](knowledge/Knowledge%20Base%20Matriz%20Precedencia%20Templates%20Universales%20Raw.md)
+- [../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md](../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md)
 - [matrices/Matriz Precedencia Instrucciones Full Custom Infraestructura.md](matrices/Matriz%20Precedencia%20Instrucciones%20Full%20Custom%20Infraestructura.md)
-- [templates/Templates Casos Uso Precedencia Infraestructura Full Custom.md](templates/Templates%20Casos%20Uso%20Precedencia%20Infraestructura%20Full%20Custom.md)
 - [doc/Mapa Jerarquía Instrucciones - Aing Z Repo (visual + Markdown).md](doc/Mapa%20Jerarqu%C3%ADa%20Instrucciones%20-%20Aing%20Z%20Repo%20(visual%20%2B%20Markdown).md)
 
 ---


### PR DESCRIPTION
## Summary
- correct relative links to knowledge base
- remove broken template links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b2c9c16483298c5987823d43c1e7