### PR TITLE
Fix README knowledges links

### DIFF
--- a/AUDT/LOTE_1/Consolidados/Lote_1_2/README.md
+++ b/AUDT/LOTE_1/Consolidados/Lote_1_2/README.md
@@ -12,7 +12,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 ## Estructura de carpetas
 
 - `/matrices/` — Matrices de precedencia, jerarquías y features. Uso y control central de lógica de input/output.
--../knowledges/` — Knowledge base, templates universales, lecciones aprendidas y profundización de features.
+- `../knowledges/` — Knowledge base, templates universales, lecciones aprendidas y profundización de features.
 - `/template/` — Plantillas y flujos para casos de uso (personalización global, proyectos, GPTs).
 - `/doc/` — Diagramas visuales, ejemplos, FAQs, documentación viva y operativa.
 
@@ -28,7 +28,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 
 ## Reglas y trazabilidad
 - Todos los archivos y templates versionados llevan fecha, autor y referencias cruzadas.
-- Cualquier override, excepción o aprendizaje debe documentarse en../knowledges/` y quedar linkeado en los READMEs.
+- Cualquier override, excepción o aprendizaje debe documentarse en `../knowledges/` y quedar linkeado en los READMEs.
 - Los outputs relevantes deben exportarse/versionarse en la knowledge base para mantener integridad y continuidad.
 
 ---

--- a/AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md
+++ b/AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md
@@ -12,7 +12,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 ## Estructura de carpetas
 
 - `/matrices/` — Matrices de precedencia, jerarquías y features. Uso y control central de lógica de input/output.
--../knowledges/` — Knowledge base, templates universales, lecciones aprendidas y profundización de features.
+- `../knowledges/` — Knowledge base, templates universales, lecciones aprendidas y profundización de features.
 - `/template/` — Plantillas y flujos para casos de uso (personalización global, proyectos, GPTs).
 - `/doc/` — Diagramas visuales, ejemplos, FAQs, documentación viva y operativa.
 
@@ -28,7 +28,7 @@ Este repositorio implementa una infraestructura modular, trazable y versionable 
 
 ## Reglas y trazabilidad
 - Todos los archivos y templates versionados llevan fecha, autor y referencias cruzadas.
-- Cualquier override, excepción o aprendizaje debe documentarse en../knowledges/` y quedar linkeado en los READMEs.
+- Cualquier override, excepción o aprendizaje debe documentarse en `../knowledges/` y quedar linkeado en los READMEs.
 - Los outputs relevantes deben exportarse/versionarse en la knowledge base para mantener integridad y continuidad.
 
 ---


### PR DESCRIPTION
## Summary
- correct bullet formatting for `../knowledges/` in consolidated and legacy READMEs
- ensure instructions reference `../knowledges/` consistently

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886b84f82c4832994e5460b632579be