### PR TITLE
Fix knowledges link in matrices readme

### DIFF
--- a/AUDT/LOTE_2/Legacy_Original/Lote_matrices/matrices_readme.md
+++ b/AUDT/LOTE_2/Legacy_Original/Lote_matrices/matrices_readme.md
@@ -23,7 +23,7 @@ Esta carpeta contiene las **matrices de precedencia, jerarquía y features** par
 
 ## Referencias cruzadas
 - [../README.md](../README.md)
-- [../knowledges/Knowledge Base Matriz Precedencia Templates Universales Raw.md](../knowledges/Knowledge%20Base%20Matriz%20Precedencia%20Templates%20Universales%20Raw.md)
+- [../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md](../../../../knowledges/Knowledge_Base_Matriz_Precedencia_Templates_Universales_Raw.md)
 - [../template/Templates Casos Uso Precedencia Infraestructura Full Custom.md](../template/Templates%20Casos%20Uso%20Precedencia%20Infraestructura%20Full%20Custom.md)
 
 ---


### PR DESCRIPTION
## Summary
- point to the knowledges base file from the matrices README using a four-level relative path

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886b8501d888329b8e7022b43902e87