### PR TITLE
Generate mapping registry and update matrix

### DIFF
--- a/chglog_main_rwb_v_4_20250729.md
+++ b/chglog_main_rwb_v_4_20250729.md
@@ -20,6 +20,12 @@
 - Procedimientos y flujos para dictado por voz, training, tuning IA y migración literal.
 - Actualización del ciclo de vida de assets y workflows, integración con matriz y glosario.
 
+
+## 2025-07-30 — Actualización incremental
+- Generado `registro_trazabilidad_total.md` con script de mapeo.
+- Nueva fila `INT·AC` y procedimiento `INT·AC·CORE` en Matrix v1.
+- Agregados triggers `TRG_AUDIT_TL` y `TRG_CONSOLIDATE_TL` en glosario y diccionario.
+
 ---
 
 ## Firma

--- a/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
+++ b/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
@@ -43,6 +43,8 @@
 | B14 | ACTV| ActiveAsset | Asset vivo/actual. | Transversal | live editor |
 | B15 | PURG| Purgatory | Directorio de obsoletos. | Transversal | cold storage |
 | B16 | DIFF| DiffAsset | Archivo de diferencias entre versiones. | Transversal | diff analysis |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | Disparador auditoría TL | Ciclo TL | event hooks |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | Disparador consolidación TL | Ciclo TL | event hooks |
 
 ## C. INSTRUCCIONES & PROC
 | ID | CODE | Name | Descripción | Jerarquía | Features (OpenAI) |

--- a/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
+++ b/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
@@ -52,6 +52,7 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 | SRC \ STG \ ROLE | CORE            | TL        | REF            | BLUE        |
 | ---------------- | --------------- | --------- | -------------- | ----------- |
 | **INT · DR**     | INT·DR·CORE     | INT·DR·TL | INT·DR·REF     | INT·DR·BLUE |
+| **INT · AC**     | INT·AC·CORE     | INT·AC·TL | INT·AC·REF     | INT·AC·BLUE |
 | **INT‑LEG · PG** | INT‑LEG·PG·CORE | ‑         | INT‑LEG·PG·REF | ‑           |
 | **EXT‑OFF · DR** | EXT‑OFF·DR·CORE | ‑         | EXT‑OFF·DR·REF | ‑           |
 | **AI · TL**      | ‑               | AI·TL·TL  | ‑              | ‑           |
@@ -68,6 +69,12 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 2. Etiquetar `STA=WIP` y registrar en BIT.
 3. WF aplicado: `WF_TUNE_FEEDBACK` → genera resultado.
 4. Auditoría semanal `WF_AUDIT_TL` decide consolidación a ACTV.
+```
+
+### INT·AC·CORE — Activo interno principal
+1. Ubicar en `/CORE/INT/`.
+2. Registrar snapshot BLN y log en BIT.
+3. Auditar mensual `WF_AUDIT_CORE`.
 ```
 
 Añadir subsecciones similares para cada combinación relevante.

--- a/registro_trazabilidad_total.md
+++ b/registro_trazabilidad_total.md
@@ -1,0 +1,24 @@
+
+## Mapeo automático (2025-07-30)
+| Ruta Legacy | Destino propuesto |
+| --- | --- |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_features_prompts.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_jerarquia_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTXfaq_avanzada_gestion_de_adjuntos.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_onboarding_gz.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_legacy_barrido_raw.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_raw_gold_scaffold.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/faq_workflows_operativo_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/jerarquia_precedencia_instrucciones_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/matriz_features_prompts_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/rawgold_scaffold_readme.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_base_aingz_t_3_infra.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_integracion_t_2_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_master_plan.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_matriz_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_onbrd_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_canvas_integrado_final_v_2.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_matriz_final.md | PENDIENTE |

--- a/rw_b_diccionario_code_triggers_v_2_20250729.md
+++ b/rw_b_diccionario_code_triggers_v_2_20250729.md
@@ -29,6 +29,8 @@
 | B14 | ACTV | ActiveAsset | "🔥 ACTV mark" | Meta | MD | log.md |
 | B15 | PURG | Purgatory | "🗑️ PURG move" | Meta | MD | archive.md |
 | B16 | DIFF | DiffAsset | "🔍 DIFF v1 v2" | Meta | MD | diff.md |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | "🔔 TRG_AUDIT_TL" | Trigger | MD | audit_tl.md |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | "🔔 TRG_CONSOLIDATE_TL" | Trigger | MD | consolidate_tl.md |
 | C01 | INS | InstructionSet | "📜 INS QA" | Doc | MD | instructions.md |
 | C02 | ENV | EnvInstruction | "🌎 ENV prod" | Doc | MD | env.md |
 | C03 | HIE | HierInstruction | "🏛️ HIE App" | Doc | MD | hie.md |


### PR DESCRIPTION
## Summary
- add automatic legacy mapping registry
- update Assets Classification Matrix with INT·AC row and procedure
- define TRG_AUDIT_TL and TRG_CONSOLIDATE_TL in glossary and dictionary
- log updates in main changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688945c303808329bf53485cbcd2e9d7