### PR TITLE
Add EXT-OFF classification and audit trigger

### DIFF
--- a/chglog_main_rwb_v_4_20250729.md
+++ b/chglog_main_rwb_v_4_20250729.md
@@ -20,6 +20,15 @@
 - Procedimientos y flujos para dictado por voz, training, tuning IA y migración literal.
 - Actualización del ciclo de vida de assets y workflows, integración con matriz y glosario.
 
+
+## 2025-07-30 — Actualización incremental
+- Generado `registro_trazabilidad_total.md` con script de mapeo.
+- Nueva fila `INT·AC` y procedimiento `INT·AC·CORE` en Matrix v1.
+- Agregados triggers `TRG_AUDIT_TL` y `TRG_CONSOLIDATE_TL` en glosario y diccionario.
+- Añadida fila `EXT‑OFF·AC` y procedimiento `EXT‑OFF·AC·REF` en Matrix v1.
+- Registrado trigger `TRG_AUDIT_EXT_OFF` en glosario y diccionario.
+- Documentado el archivo `registro_trazabilidad_total.md` en el README principal.
+
 ---
 
 ## Firma

--- a/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
+++ b/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
@@ -43,7 +43,10 @@
 | B14 | ACTV| ActiveAsset | Asset vivo/actual. | Transversal | live editor |
 | B15 | PURG| Purgatory | Directorio de obsoletos. | Transversal | cold storage |
 | B16 | DIFF| DiffAsset | Archivo de diferencias entre versiones. | Transversal | diff analysis |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | Disparador auditoría TL | Ciclo TL | event hooks |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | Disparador consolidación TL | Ciclo TL | event hooks |
 
+| B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | Disparador auditoría de assets externos oficiales | Ciclo EXT | event hooks |
 ## C. INSTRUCCIONES & PROC
 | ID | CODE | Name | Descripción | Jerarquía | Features (OpenAI) |
 |----|------|------|-------------|-----------|-------------------|

--- a/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
+++ b/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
@@ -52,8 +52,10 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 | SRC \ STG \ ROLE | CORE            | TL        | REF            | BLUE        |
 | ---------------- | --------------- | --------- | -------------- | ----------- |
 | **INT · DR**     | INT·DR·CORE     | INT·DR·TL | INT·DR·REF     | INT·DR·BLUE |
+| **INT · AC**     | INT·AC·CORE     | INT·AC·TL | INT·AC·REF     | INT·AC·BLUE |
 | **INT‑LEG · PG** | INT‑LEG·PG·CORE | ‑         | INT‑LEG·PG·REF | ‑           |
 | **EXT‑OFF · DR** | EXT‑OFF·DR·CORE | ‑         | EXT‑OFF·DR·REF | ‑           |
+| **EXT‑OFF · AC** | EXT‑OFF·AC·CORE | EXT‑OFF·AC·TL | EXT‑OFF·AC·REF | EXT‑OFF·AC·BLUE |
 | **AI · TL**      | ‑               | AI·TL·TL  | ‑              | ‑           |
 
 *(Completar según necesidades; combinaciones vacías implican flujo no usual.)*
@@ -69,6 +71,17 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 3. WF aplicado: `WF_TUNE_FEEDBACK` → genera resultado.
 4. Auditoría semanal `WF_AUDIT_TL` decide consolidación a ACTV.
 ```
+
+### INT·AC·CORE — Activo interno principal
+1. Ubicar en `/CORE/INT/`.
+2. Registrar snapshot BLN y log en BIT.
+3. Auditar mensual `WF_AUDIT_CORE`.
+```
+### EXT‑OFF·AC·REF — Referencia externa oficial activa
+1. Colocar en `/DOC/EXT_OFF/`.
+2. Verificar licencias y registrar en BIT.
+3. Auditoría trimestral `WF_AUDIT_EXT_OFF`.
+
 
 Añadir subsecciones similares para cada combinación relevante.
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Este README centraliza las referencias, estructura, reglas y logs para operar el
 - **AUDT/** – Auditorías legacy y bitácoras (`CHG_LOG_AUDITORIA_20250725.md`)
 - **doc/** – Documentación formal y master-plans
 - **scripts/** – Utilidades y ETL
+- **registro_trazabilidad_total.md** – Mapeo automático de archivos legacy → RwB (generado con `scripts/mapping.py`)
 - **matrices/** – Matrices de precedencia y trazabilidad
 - **backup/** – Respaldo y purgatorio (`backup/purgatorio/`)
 
@@ -68,6 +69,14 @@ Las pruebas unitarias están en la carpeta `tests/`. Para correrlas se utiliza `
 pip install pytest  # si no está instalado
 pytest
 ```
+
+## 8. Generar mapeo de legacy
+Para actualizar `registro_trazabilidad_total.md` ejecuta el script de mapeo:
+
+```bash
+python scripts/mapping.py
+```
+
 
 ---
 

--- a/registro_trazabilidad_total.md
+++ b/registro_trazabilidad_total.md
@@ -1,0 +1,24 @@
+
+## Mapeo automático (2025-07-30)
+| Ruta Legacy | Destino propuesto |
+| --- | --- |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_features_prompts.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_jerarquia_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTXfaq_avanzada_gestion_de_adjuntos.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_onboarding_gz.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_legacy_barrido_raw.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_raw_gold_scaffold.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/faq_workflows_operativo_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/jerarquia_precedencia_instrucciones_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/matriz_features_prompts_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/rawgold_scaffold_readme.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_base_aingz_t_3_infra.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_integracion_t_2_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_master_plan.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_matriz_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_onbrd_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_canvas_integrado_final_v_2.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_matriz_final.md | PENDIENTE |

--- a/rw_b_checklist_avances_v_1_20250730.md
+++ b/rw_b_checklist_avances_v_1_20250730.md
@@ -1,0 +1,12 @@
+# RwB_CHECKLIST_AVANCES_v1_20250730.md
+
+> Checklist incremental de tareas ejecutadas según el Master Plan v3.
+
+- [x] Preparar entorno de ejecución (`pip install` dependencias básicas).
+- [x] Ejecutar scripts de auditoría y mapeo (`class_scan.py`, `mapping.py`).
+- [x] Validar pruebas automáticas (`pytest`).
+- [x] Completar combinaciones faltantes en la Matrix y registrar procedimientos.
+- [x] Sincronizar glosario y diccionario con nuevos códigos.
+- [x] Registrar avances en el changelog principal.
+- [ ] Aplicar workflows de auditoría, dictado y migración según roadmap.
+

--- a/rw_b_diccionario_code_triggers_v_2_20250729.md
+++ b/rw_b_diccionario_code_triggers_v_2_20250729.md
@@ -29,6 +29,9 @@
 | B14 | ACTV | ActiveAsset | "🔥 ACTV mark" | Meta | MD | log.md |
 | B15 | PURG | Purgatory | "🗑️ PURG move" | Meta | MD | archive.md |
 | B16 | DIFF | DiffAsset | "🔍 DIFF v1 v2" | Meta | MD | diff.md |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | "🔔 TRG_AUDIT_TL" | Trigger | MD | audit_tl.md |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | "🔔 TRG_CONSOLIDATE_TL" | Trigger | MD | consolidate_tl.md |
+| B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | "🔔 TRG_AUDIT_EXT_OFF" | Trigger | MD | audit_ext_off.md |
 | C01 | INS | InstructionSet | "📜 INS QA" | Doc | MD | instructions.md |
 | C02 | ENV | EnvInstruction | "🌎 ENV prod" | Doc | MD | env.md |
 | C03 | HIE | HierInstruction | "🏛️ HIE App" | Doc | MD | hie.md |


### PR DESCRIPTION
## Summary
- extend asset matrix with `EXT-OFF·AC` row and procedure
- sync glossary and trigger dictionary with `TRG_AUDIT_EXT_OFF`
- record changes in the main changelog
- update progress checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688945c303808329bf53485cbcd2e9d7