### PR TITLE
Expand asset matrix and update docs

### DIFF
--- a/chglog_main_rwb_v_4_20250729.md
+++ b/chglog_main_rwb_v_4_20250729.md
@@ -20,6 +20,20 @@
 - Procedimientos y flujos para dictado por voz, training, tuning IA y migración literal.
 - Actualización del ciclo de vida de assets y workflows, integración con matriz y glosario.
 
+
+## 2025-07-30 — Actualización incremental
+- Generado `registro_trazabilidad_total.md` con script de mapeo.
+- Nueva fila `INT·AC` y procedimiento `INT·AC·CORE` en Matrix v1.
+- Agregados triggers `TRG_AUDIT_TL` y `TRG_CONSOLIDATE_TL` en glosario y diccionario.
+- Añadida fila `EXT‑OFF·AC` y procedimiento `EXT‑OFF·AC·REF` en Matrix v1.
+- Registrado trigger `TRG_AUDIT_EXT_OFF` en glosario y diccionario.
+- Documentado el archivo `registro_trazabilidad_total.md` en el README principal.
+
+## 2025-07-30 — Expansión de Matrix
+- Añadidas múltiples filas en Matrix v1 cubriendo BK, PG, AU y nuevos orígenes.
+- Ejemplos de procedimiento para `INT·BK·REF`, `EXT‑OFF·BK·CORE`, `EXT‑COM·AC·TL` y `AI·DR·TL`.
+- Actualizado checklist de avances con tareas cumplidas.
+
 ---
 
 ## Firma

--- a/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
+++ b/knowledges/glossary/rw_b_glosario_code_v_2_20250729.md
@@ -43,7 +43,12 @@
 | B14 | ACTV| ActiveAsset | Asset vivo/actual. | Transversal | live editor |
 | B15 | PURG| Purgatory | Directorio de obsoletos. | Transversal | cold storage |
 | B16 | DIFF| DiffAsset | Archivo de diferencias entre versiones. | Transversal | diff analysis |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | Disparador auditoría TL | Ciclo TL | event hooks |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | Disparador consolidación TL | Ciclo TL | event hooks |
 
+| B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | Disparador auditoría de assets externos oficiales | Ciclo EXT | event hooks |
+| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | Disparador auditoría de respaldos | Ciclo BK | event hooks |
+| B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | Disparador training assets comunidad externa | Ciclo TL | event hooks |
 ## C. INSTRUCCIONES & PROC
 | ID | CODE | Name | Descripción | Jerarquía | Features (OpenAI) |
 |----|------|------|-------------|-----------|-------------------|

--- a/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
+++ b/matrices/rw_b_assets_classification_matrix_v_1_20250729.md
@@ -52,9 +52,24 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 | SRC \ STG \ ROLE | CORE            | TL        | REF            | BLUE        |
 | ---------------- | --------------- | --------- | -------------- | ----------- |
 | **INT · DR**     | INT·DR·CORE     | INT·DR·TL | INT·DR·REF     | INT·DR·BLUE |
+| **INT · AC**     | INT·AC·CORE     | INT·AC·TL | INT·AC·REF     | INT·AC·BLUE |
 | **INT‑LEG · PG** | INT‑LEG·PG·CORE | ‑         | INT‑LEG·PG·REF | ‑           |
 | **EXT‑OFF · DR** | EXT‑OFF·DR·CORE | ‑         | EXT‑OFF·DR·REF | ‑           |
-| **AI · TL**      | ‑               | AI·TL·TL  | ‑              | ‑           |
+| **EXT‑OFF · AC** | EXT‑OFF·AC·CORE | EXT‑OFF·AC·TL | EXT‑OFF·AC·REF | EXT‑OFF·AC·BLUE |
+| **INT · BK**     | INT·BK·CORE     | ‑         | INT·BK·REF     | ‑ |
+| **INT · PG**     | INT·PG·CORE     | ‑         | INT·PG·REF     | ‑ |
+| **INT · AU**     | INT·AU·CORE     | INT·AU·TL | INT·AU·REF     | ‑ |
+| **INT · TL**     | ‑               | INT·TL·TL | ‑              | ‑ |
+| **INT‑LEG · BK** | INT‑LEG·BK·CORE | ‑         | INT‑LEG·BK·REF | ‑ |
+| **INT‑LEG · LG** | INT‑LEG·LG·CORE | ‑         | INT‑LEG·LG·REF | ‑ |
+| **EXT‑OFF · BK** | EXT‑OFF·BK·CORE | ‑         | EXT‑OFF·BK·REF | ‑ |
+| **EXT‑OFF · PG** | EXT‑OFF·PG·CORE | ‑         | EXT‑OFF·PG·REF | ‑ |
+| **EXT‑COM · DR** | EXT‑COM·DR·CORE | ‑         | EXT‑COM·DR·REF | ‑ |
+| **EXT‑COM · AC** | EXT‑COM·AC·CORE | EXT‑COM·AC·TL | EXT‑COM·AC·REF | EXT‑COM·AC·BLUE |
+| **EXT‑COM · PG** | EXT‑COM·PG·CORE | ‑         | EXT‑COM·PG·REF | ‑ |
+| **AI · DR**      | ‑               | AI·DR·TL  | ‑              | ‑ |
+| **AI · AC**      | ‑               | AI·AC·TL  | ‑              | ‑ |
+| **AI · TL**      | ‑               | AI·TL·TL  | ‑              | ‑ |
 
 *(Completar según necesidades; combinaciones vacías implican flujo no usual.)*
 
@@ -69,6 +84,37 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 3. WF aplicado: `WF_TUNE_FEEDBACK` → genera resultado.
 4. Auditoría semanal `WF_AUDIT_TL` decide consolidación a ACTV.
 ```
+
+### INT·AC·CORE — Activo interno principal
+1. Ubicar en `/CORE/INT/`.
+2. Registrar snapshot BLN y log en BIT.
+3. Auditar mensual `WF_AUDIT_CORE`.
+```
+### EXT‑OFF·AC·REF — Referencia externa oficial activa
+1. Colocar en `/DOC/EXT_OFF/`.
+2. Verificar licencias y registrar en BIT.
+3. Auditoría trimestral `WF_AUDIT_EXT_OFF`.
+
+### INT·BK·REF — Respaldo interno de referencia
+1. Guardar en `/BACKUP/INT/`.
+2. Etiquetar `STA=BCK` y registrar en BIT.
+3. Auditoría semestral `WF_AUDIT_BACKUP`.
+
+### EXT‑OFF·BK·CORE — Respaldo externo oficial
+1. Almacenar en `/BACKUP/EXT_OFF/` con checksum.
+2. Revisar licencias antes de archivarlo.
+3. Auditoría anual `WF_AUDIT_EXT_OFF`.
+
+### EXT‑COM·AC·TL — Activos comunitarios de Training
+1. Guardar en `/KNS/TL/EXT_COM/`.
+2. Validar integridad y origen.
+3. Ejecutar `WF_TRAIN_EXT_COM` para integrar feedback.
+
+### AI·DR·TL — Draft IA para entrenamiento
+1. Crear en `/TMP/AI/` con prefijo `draft_`.
+2. Revisar coherencia antes de mover a `/KNS/TL`.
+3. Auditoría rápida `WF_AUDIT_TL`.
+
 
 Añadir subsecciones similares para cada combinación relevante.
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Este README centraliza las referencias, estructura, reglas y logs para operar el
 - **AUDT/** – Auditorías legacy y bitácoras (`CHG_LOG_AUDITORIA_20250725.md`)
 - **doc/** – Documentación formal y master-plans
 - **scripts/** – Utilidades y ETL
+- **registro_trazabilidad_total.md** – Mapeo automático de archivos legacy → RwB (generado con `scripts/mapping.py`)
 - **matrices/** – Matrices de precedencia y trazabilidad
 - **backup/** – Respaldo y purgatorio (`backup/purgatorio/`)
 
@@ -68,6 +69,14 @@ Las pruebas unitarias están en la carpeta `tests/`. Para correrlas se utiliza `
 pip install pytest  # si no está instalado
 pytest
 ```
+
+## 8. Generar mapeo de legacy
+Para actualizar `registro_trazabilidad_total.md` ejecuta el script de mapeo:
+
+```bash
+python scripts/mapping.py
+```
+
 
 ---
 

--- a/registro_trazabilidad_total.md
+++ b/registro_trazabilidad_total.md
@@ -1,0 +1,24 @@
+
+## Mapeo automático (2025-07-30)
+| Ruta Legacy | Destino propuesto |
+| --- | --- |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_features_prompts.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTX_jerarquia_instrucciones.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_MTXfaq_avanzada_gestion_de_adjuntos.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/Legacy_onboarding_gz.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_1/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/README.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_legacy_barrido_raw.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/aing_z_repo_raw_gold_scaffold.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/faq_workflows_operativo_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/jerarquia_precedencia_instrucciones_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/matriz_features_prompts_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/rawgold_scaffold_readme.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_base_aingz_t_3_infra.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_integracion_t_2_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_master_plan.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_matriz_memorias_historiales.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/readme_onbrd_v_1_lote_1_20250724.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_canvas_integrado_final_v_2.md | PENDIENTE |
+| AUDT/LOTE_1/Legacy_Original/Lote_1_2/t_3_raw_gold_matriz_final.md | PENDIENTE |

--- a/rw_b_checklist_avances_v_1_20250730.md
+++ b/rw_b_checklist_avances_v_1_20250730.md
@@ -1,0 +1,13 @@
+# RwB_CHECKLIST_AVANCES_v1_20250730.md
+
+> Checklist incremental de tareas ejecutadas según el Master Plan v3.
+
+- [x] Preparar entorno de ejecución (`pip install` dependencias básicas).
+- [x] Ejecutar scripts de auditoría y mapeo (`class_scan.py`, `mapping.py`).
+- [x] Validar pruebas automáticas (`pytest`).
+- [x] Completar combinaciones faltantes en la Matrix y registrar procedimientos.
+- [x] Sincronizar glosario y diccionario con nuevos códigos.
+- [x] Registrar avances en el changelog principal.
+- [x] Expandida Matrix v1 con filas BK, PG, AU y EXT-COM.
+- [ ] Aplicar workflows de auditoría, dictado y migración según roadmap.
+

--- a/rw_b_diccionario_code_triggers_v_2_20250729.md
+++ b/rw_b_diccionario_code_triggers_v_2_20250729.md
@@ -29,6 +29,11 @@
 | B14 | ACTV | ActiveAsset | "🔥 ACTV mark" | Meta | MD | log.md |
 | B15 | PURG | Purgatory | "🗑️ PURG move" | Meta | MD | archive.md |
 | B16 | DIFF | DiffAsset | "🔍 DIFF v1 v2" | Meta | MD | diff.md |
+| B17 | TRG_AUDIT_TL | TriggerAuditTL | "🔔 TRG_AUDIT_TL" | Trigger | MD | audit_tl.md |
+| B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | "🔔 TRG_CONSOLIDATE_TL" | Trigger | MD | consolidate_tl.md |
+| B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | "🔔 TRG_AUDIT_EXT_OFF" | Trigger | MD | audit_ext_off.md |
+| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | "🔔 TRG_AUDIT_BACKUP" | Trigger | MD | audit_backup.md |
+| B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | "🔔 TRG_TRAIN_EXT_COM" | Trigger | MD | train_ext_com.md |
 | C01 | INS | InstructionSet | "📜 INS QA" | Doc | MD | instructions.md |
 | C02 | ENV | EnvInstruction | "🌎 ENV prod" | Doc | MD | env.md |
 | C03 | HIE | HierInstruction | "🏛️ HIE App" | Doc | MD | hie.md |


### PR DESCRIPTION
## Summary
- broaden asset classification matrix with rows for backup, purgatory and external community
- document new procedures for backup, community training and AI drafts
- register expansion in changelog and checklist
- add backup and community training triggers to glossary and dictionary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688945c303808329bf53485cbcd2e9d7