### PR TITLE
Update references to latest docs and workflows

### DIFF
--- a/WF/chg_log_wf_purgatorio_20250725.md
+++ b/WF/chg_log_wf_purgatorio_20250725.md
@@ -15,7 +15,7 @@
 ---
 
 ## 3. Archivos activos/actuales (WF/)
-- `rw_b_wf_consolidacion_files_activos_v_2_20250725.md`
+ - ~~`rw_b_wf_consolidacion_files_activos_v_2_20250725.md`~~ (retirado)
 - `rw_b_wf_auditoria_legacy_v_3_20250725.md`
 - `wf_migracion_final_legacy_rw_b_v_1_20250725.md`
 - `rw_b_wf_relevamiento_ideas_v_1.md`

--- a/WF/rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md
+++ b/WF/rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md
@@ -8,7 +8,7 @@ Definir el procedimiento formal para auditar y documentar el cierre de ciclo/hil
 ---
 
 ## 2. Archivos y rutas requeridas
-- Glosario: `rw_b_glosario_code_v_1_core.md`
+ - Glosario: `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`
 - Workflow central: `wk_feedtrn_eval_actv_raw_v_2_20250725.md`
 - Relevamiento ideas: `rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md`
 
@@ -26,7 +26,7 @@ Definir el procedimiento formal para auditar y documentar el cierre de ciclo/hil
 ```
 # Cierre de ciclo — Ejemplo
 - Lessons learned: “La tabla de outputs y la checklist batch permiten validar cobertura total del hilo.”
-- Mapping: [`WK_FEEDTRN_EVAL_ACTV_RAW_V2_20250725.md`, `rw_b_glosario_code_v_1_core.md`]
+ - Mapping: [`WK_FEEDTRN_EVAL_ACTV_RAW_V2_20250725.md`, `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`]
 - Checklist:
     - [x] Lessons learned documentadas
     - [x] Mapping de outputs actualizado

--- a/WF/rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md
+++ b/WF/rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md
@@ -8,7 +8,7 @@ Definir el procedimiento literal y modular para barrido de ideas, brainstorming,
 ---
 
 ## 2. Archivos y rutas requeridas
-- Glosario: `rw_b_glosario_code_v_1_core.md`
+ - Glosario: `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`
 - Workflow central: `wk_feedtrn_eval_actv_raw_v_2_20250725.md`
 - Workflow cierre hilo: `rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md`
 

--- a/chglog_main_rwb_v_5_20250730_actv.md
+++ b/chglog_main_rwb_v_5_20250730_actv.md
@@ -13,6 +13,7 @@
 - Re‑alineación de referencias al blueprint DirArchPlan v4, glosario v2, diccionario v2 y Matrix v1.
 - Checklist QA añadido al workflow `WF_CONS_ACTV`.
 - Añadido `README.md` en la raíz (copia literal de `readme_rw_b_repo_main_v_5_20250730_activo.md`).
+- Actualizados enlaces: `README.md`, `mpln_master_plan_aingz_rw_b_v_20250730_v_4_activo.md`, glosario v2 y workflow auditoría v3; retirado link inexistente de consolidación.
 
 ---
 

--- a/o3_full_instructions.md
+++ b/o3_full_instructions.md
@@ -104,7 +104,7 @@ Este README centraliza las referencias, estructura, reglas y logs para operar el
 
 ## 2. Estructura general del repositorio (RawBase 2025)
 - **WF/** – Workflows activos, logs y bitácora de versiones (`chg_log_wf_purgatorio_20250725.md`)
-- **knowledges/** – Glosario, contextos y lessons learned (`rw_b_glosario_code_v_1_core_20250725.md`)
+ - **knowledges/** – Glosario, contextos y lessons learned (`knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`)
 - **Learn/** – Memoria viva incremental
 - **template/** – Plantillas de naming y README
 - **AUDT/** – Auditorías legacy y bitácoras (`CHG_LOG_AUDITORIA_20250725.md`)
@@ -117,7 +117,7 @@ Este README centraliza las referencias, estructura, reglas y logs para operar el
 ---
 
 ## 3. Reglas y metodología de operación
-- Seguir siempre el glosario core (`knowledges/rw_b_glosario_code_v_1_core.md`) y plantilla de naming (`template/naming/rw_b_naming_template_v_1.md`).
+ - Seguir siempre el glosario core (`knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`) y plantilla de naming (`template/naming/rw_b_naming_template_v_1.md`).
 - Usar el plan de directorio (`rwb_repo_directory_plan_v_1.md`), workflows (`WF/`), logs y bitácoras como referencia operativa.
 - Toda acción (movimiento, auditoría, integración) debe registrar logs en el archivo o carpeta correspondiente y actualizar el changelog maestro.
 - Checklist de cobertura, versionado y referenciación cruzada antes de cada merge, integración o purga.
@@ -661,8 +661,8 @@ Se complementa con el README consolidado, el MasterPlan (MPLN) y el glosario viv
 ---
 
 ## 2. Primeros pasos y estructura base
-1. Leer el README consolidado (`README_CONSOLIDADO_AINGZ_MAIN_20250725.md`) y el MasterPlan (`MPLN_MASTER_PLAN_AINGZ_RW_B_v_20250725.md`).
-2. Familiarizarse con la estructura de carpetas y naming (ver glosario `rw_b_glosario_code_v_1_core.md`).
+1. Leer el README consolidado (`README.md`) y el MasterPlan (`mpln_master_plan_aingz_rw_b_v_20250730_v_4_activo.md`).
+2. Familiarizarse con la estructura de carpetas y naming (ver glosario `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`).
 3. Revisar los workflows activos (`WF/`), templates de naming y logs/changelogs de cada ciclo.
 4. Para onboarding IA/agente: sincronizar glosario, mapeos y reglas del pipeline operativo.
 
@@ -677,10 +677,10 @@ Se complementa con el README consolidado, el MasterPlan (MPLN) y el glosario viv
 ---
 
 ## 4. Links útiles y recursos
-- **Glosario:** `KNOWLEDGES/rw_b_glosario_code_v_1_core.md`
-- **README consolidado:** `README_CONSOLIDADO_AINGZ_MAIN_20250725.md`
-- **MasterPlan:** `MPLN_MASTER_PLAN_AINGZ_RW_B_v_20250725.md`
-- **Workflow auditoría:** `WF/rw_b_wf_auditoria_legacy_v_2_20250724.md` y `WF/rw_b_wf_consolidacion_files_activos_v2_20250725.md`
+ - **Glosario:** `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`
+ - **README consolidado:** `README.md`
+ - **MasterPlan:** `mpln_master_plan_aingz_rw_b_v_20250730_v_4_activo.md`
+ - **Workflow auditoría:** `WF/rw_b_wf_auditoria_legacy_v_3_20250725.md`
 - **Templates y naming:** `template/`, `template/naming/`
 - **Logs/changelog:** `LOG/`, `KNOWLEDGES/LEARN/`
 

--- a/onbrd_welcome_onboarding_gz_rw_b_v_20250725.md
+++ b/onbrd_welcome_onboarding_gz_rw_b_v_20250725.md
@@ -9,8 +9,8 @@ Se complementa con el README consolidado, el MasterPlan (MPLN) y el glosario viv
 ---
 
 ## 2. Primeros pasos y estructura base
-1. Leer el README consolidado (`README_CONSOLIDADO_AINGZ_MAIN_20250725.md`) y el MasterPlan (`MPLN_MASTER_PLAN_AINGZ_RW_B_v_20250725.md`).
-2. Familiarizarse con la estructura de carpetas y naming (ver glosario `rw_b_glosario_code_v_1_core.md`).
+1. Leer el README consolidado (`README.md`) y el MasterPlan (`mpln_master_plan_aingz_rw_b_v_20250730_v_4_activo.md`).
+2. Familiarizarse con la estructura de carpetas y naming (ver glosario `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`).
 3. Revisar los workflows activos (`WF/`), templates de naming y logs/changelogs de cada ciclo.
 4. Para onboarding IA/agente: sincronizar glosario, mapeos y reglas del pipeline operativo.
 
@@ -25,10 +25,10 @@ Se complementa con el README consolidado, el MasterPlan (MPLN) y el glosario viv
 ---
 
 ## 4. Links útiles y recursos
-- **Glosario:** `KNOWLEDGES/rw_b_glosario_code_v_1_core.md`
-- **README consolidado:** `README_CONSOLIDADO_AINGZ_MAIN_20250725.md`
-- **MasterPlan:** `MPLN_MASTER_PLAN_AINGZ_RW_B_v_20250725.md`
-- **Workflow auditoría:** `WF/rw_b_wf_auditoria_legacy_v_2_20250724.md` y `WF/rw_b_wf_consolidacion_files_activos_v2_20250725.md`
+ - **Glosario:** `knowledges/glossary/rw_b_glosario_code_v_2_20250729.md`
+ - **README consolidado:** `README.md`
+ - **MasterPlan:** `mpln_master_plan_aingz_rw_b_v_20250730_v_4_activo.md`
+ - **Workflow auditoría:** `WF/rw_b_wf_auditoria_legacy_v_3_20250725.md`
 - **Templates y naming:** `template/`, `template/naming/`
 - **Logs/changelog:** `LOG/`, `KNOWLEDGES/LEARN/`
 


### PR DESCRIPTION
## Summary
- update onboarding and instructions to point at current README, MasterPlan and glossary
- switch workflow references to v3 and drop obsolete consolidation file
- document workflow cleanup in `chg_log_wf_purgatorio`
- log these updates in the main changelog

## Testing
- `pip install psutil py-cpuinfo GPUtil wmi`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab702e6c0832993f86a69a201c3d4