### PR TITLE
Update workflow references

### DIFF
--- a/WF/README.md
+++ b/WF/README.md
@@ -9,7 +9,7 @@ Repositorio de workflows operativos: auditoría, dictado, relevamientos y migrac
 - `rw_b_wf_dictado_v_1.md`
 - `rw_b_wf_relev_hilo_assets_v_1_20250729.md`
 - `rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md`
-- `wf_cons_actv_transcripcion_raw_v_3_20250725.md`
+- `wf_cons_actv_transcripcion_raw_v_4_20250730_draft.md`
 - `wf_migracion_final_legacy_rw_b_v_1_20250725.md`
 - `wk_feedtrn_eval_actv_raw_v_2_20250725.md`
 

--- a/WF/rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md
+++ b/WF/rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md
@@ -8,7 +8,7 @@ Definir el procedimiento formal para auditar y documentar el cierre de ciclo/hil
 ---
 
 ## 2. Archivos y rutas requeridas
-- Glosario: `rw_b_glosario_code_v_1_core.md`
+- Glosario: `rw_b_glosario_code_v_2_20250729.md`
 - Workflow central: `wk_feedtrn_eval_actv_raw_v_2_20250725.md`
 - Relevamiento ideas: `rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md`
 
@@ -26,7 +26,7 @@ Definir el procedimiento formal para auditar y documentar el cierre de ciclo/hil
 ```
 # Cierre de ciclo — Ejemplo
 - Lessons learned: “La tabla de outputs y la checklist batch permiten validar cobertura total del hilo.”
-- Mapping: [`WK_FEEDTRN_EVAL_ACTV_RAW_V2_20250725.md`, `rw_b_glosario_code_v_1_core.md`]
+- Mapping: [`WK_FEEDTRN_EVAL_ACTV_RAW_V2_20250725.md`, `rw_b_glosario_code_v_2_20250729.md`]
 - Checklist:
     - [x] Lessons learned documentadas
     - [x] Mapping de outputs actualizado

--- a/WF/rw_b_wf_inicio_repo_check_v_1_20250731.md
+++ b/WF/rw_b_wf_inicio_repo_check_v_1_20250731.md
@@ -19,7 +19,7 @@
 | W02 | Scan cambios locales     | DIFF      | `git status` + `git diff` para detectar modificaciones.      | `diff_session.log`                      |
 | W03 | Mapping Legacy           | MAP       | Ejecutar `python scripts/mapping.py --no-header`.            | `registro_trazabilidad_total.md`        |
 | W04 | CrossRef Matrix/Glosario | XRF       | Validar códigos nuevos vs Matrix y Glosario.                 | `xrf_report.md`                         |
-| W05 | Actualizar Changelog     | CHG       | Registrar entrada de sesión en `chglog_main_rwb_v_4*.md`.    | changelog actualizado                   |
+| W05 | Actualizar Changelog     | CHG       | Registrar entrada de sesión en `chglog_main_rwb_v_5_20250730_actv.md`.    | changelog actualizado                   |
 | W06 | Correr Pruebas           | TST       | `pytest -q` para validar scripts.                            | reporte pytest                          |
 | W07 | Commit sesión            | GIT       | `git add` + `git commit` (push opcional).                    | commit                                  |
 

--- a/WF/rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md
+++ b/WF/rw_b_wf_relevamiento_ideas_actv_v_1_20250725.md
@@ -8,7 +8,7 @@ Definir el procedimiento literal y modular para barrido de ideas, brainstorming,
 ---
 
 ## 2. Archivos y rutas requeridas
-- Glosario: `rw_b_glosario_code_v_1_core.md`
+- Glosario: `rw_b_glosario_code_v_2_20250729.md`
 - Workflow central: `wk_feedtrn_eval_actv_raw_v_2_20250725.md`
 - Workflow cierre hilo: `rw_b_wf_auditoria_cierre_hilo_actv_v_1_20250725.md`
 

--- a/chglog_main_rwb_v_5_20250730_actv.md
+++ b/chglog_main_rwb_v_5_20250730_actv.md
@@ -46,6 +46,11 @@
 ### Workflow de inicio (31‑07‑2025)
 - Creado `WF_INICIO_REPO_CHECK` y agregado código `WF_INIT` al glosario/diccionario【18†L23-L26】.
 
+### Correcciones menores (31‑07‑2025)
+- WF/README actualiza referencia a `wf_cons_actv_transcripcion_raw_v_4_20250730_draft.md`.
+- Auditoría de cierre y relevamiento de ideas apuntan al glosario v2.
+- `WF_INICIO_REPO_CHECK` refiere ahora al changelog `chglog_main_rwb_v_5_20250730_actv.md`.
+
 ---
 
 ## 2025-07-25 — Release v2


### PR DESCRIPTION
## Summary
- update transcription workflow link in `WF/README.md`
- point to glosario v2 in workflow docs
- update changelog reference in repo init workflow
- log these corrections in main changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab70b9fdc83299e95e4f8be5ff703