### PR TITLE
Add detailed README templates for BACKUP buckets

### DIFF
--- a/AingZ_Platform_main/BACKUP/AI/README.md
+++ b/AingZ_Platform_main/BACKUP/AI/README.md
@@ -1,0 +1,37 @@
+# BACKUP/AI — README v1
+
+> **STATUS:** `PENDIENTE`
+> **Última actualización:** 2025-08-02 | Autor: Gastón Zelechower
+
+---
+
+## 1. Resumen
+Descripción pendiente.
+
+## 2. Snapshots / Contexto
+- Carpeta de snapshots relacionada: `[./SNAPSHOTS/]`
+- Enlaces a versiones relevantes o backups IA: `[./SNAPSHOTS_CTX/]`
+
+## 3. Crossref y Mapping
+- **Referencia ascendente:** `[../]`
+- **Referencias laterales:** `[../EXT/]`, `[../INT/]`
+- **Buckets destino típicos:** `[../../PURGATORIO/AI/]`, `[../../CORE/]`
+- **Crossref central:** `[Mapa Global](../../DOC/MPLN/crossref_global.md)`
+- **Flujos/Pipelines relevantes:** `[../../WF/pipeline_backup_ai.md]`, `[../../PIPELINES/pipeline_backup_ai.md]`
+
+## 4. Precedencia en el Árbol de Directorios
+```text
+AingZ_Platform_main/
+└── BACKUP/
+    └── AI/
+```
+
+## 5. Pipeline y Workflows (Ciclo de Vida)
+1. **Ingreso / LEGACY o TMP:** `[../../WF/wf_ingreso_backup_ai.md]`
+2. **Staging / MIG:** `[../../WF/wf_staging_backup_ai.md]`
+3. **Consolidación / CORE:** `[../../WF/wf_consolidacion_backup_ai.md]`
+4. **Backup / Eliminación:** `[../../WF/wf_backup_backup_ai.md]`
+
+---
+Completar todos los campos con links activos una vez creada la estructura real.
+

--- a/AingZ_Platform_main/BACKUP/EXT/README.md
+++ b/AingZ_Platform_main/BACKUP/EXT/README.md
@@ -1,0 +1,37 @@
+# BACKUP/EXT — README v1
+
+> **STATUS:** `PENDIENTE`
+> **Última actualización:** 2025-08-02 | Autor: Gastón Zelechower
+
+---
+
+## 1. Resumen
+Descripción pendiente.
+
+## 2. Snapshots / Contexto
+- Carpeta de snapshots relacionada: `[./SNAPSHOTS/]`
+- Enlaces a versiones relevantes o backups IA: `[./SNAPSHOTS_CTX/]`
+
+## 3. Crossref y Mapping
+- **Referencia ascendente:** `[../]`
+- **Referencias laterales:** `[../AI/]`, `[../INT/]`
+- **Buckets destino típicos:** `[../../PURGATORIO/EXT/]`, `[../../CORE/]`
+- **Crossref central:** `[Mapa Global](../../DOC/MPLN/crossref_global.md)`
+- **Flujos/Pipelines relevantes:** `[../../WF/pipeline_backup_ext.md]`, `[../../PIPELINES/pipeline_backup_ext.md]`
+
+## 4. Precedencia en el Árbol de Directorios
+```text
+AingZ_Platform_main/
+└── BACKUP/
+    └── EXT/
+```
+
+## 5. Pipeline y Workflows (Ciclo de Vida)
+1. **Ingreso / LEGACY o TMP:** `[../../WF/wf_ingreso_backup_ext.md]`
+2. **Staging / MIG:** `[../../WF/wf_staging_backup_ext.md]`
+3. **Consolidación / CORE:** `[../../WF/wf_consolidacion_backup_ext.md]`
+4. **Backup / Eliminación:** `[../../WF/wf_backup_backup_ext.md]`
+
+---
+Completar todos los campos con links activos una vez creada la estructura real.
+

--- a/AingZ_Platform_main/BACKUP/INT/README.md
+++ b/AingZ_Platform_main/BACKUP/INT/README.md
@@ -1,0 +1,37 @@
+# BACKUP/INT — README v1
+
+> **STATUS:** `PENDIENTE`
+> **Última actualización:** 2025-08-02 | Autor: Gastón Zelechower
+
+---
+
+## 1. Resumen
+Descripción pendiente.
+
+## 2. Snapshots / Contexto
+- Carpeta de snapshots relacionada: `[./SNAPSHOTS/]`
+- Enlaces a versiones relevantes o backups IA: `[./SNAPSHOTS_CTX/]`
+
+## 3. Crossref y Mapping
+- **Referencia ascendente:** `[../]`
+- **Referencias laterales:** `[../AI/]`, `[../EXT/]`
+- **Buckets destino típicos:** `[../../PURGATORIO/INT/]`, `[../../CORE/]`
+- **Crossref central:** `[Mapa Global](../../DOC/MPLN/crossref_global.md)`
+- **Flujos/Pipelines relevantes:** `[../../WF/pipeline_backup_int.md]`, `[../../PIPELINES/pipeline_backup_int.md]`
+
+## 4. Precedencia en el Árbol de Directorios
+```text
+AingZ_Platform_main/
+└── BACKUP/
+    └── INT/
+```
+
+## 5. Pipeline y Workflows (Ciclo de Vida)
+1. **Ingreso / LEGACY o TMP:** `[../../WF/wf_ingreso_backup_int.md]`
+2. **Staging / MIG:** `[../../WF/wf_staging_backup_int.md]`
+3. **Consolidación / CORE:** `[../../WF/wf_consolidacion_backup_int.md]`
+4. **Backup / Eliminación:** `[../../WF/wf_backup_backup_int.md]`
+
+---
+Completar todos los campos con links activos una vez creada la estructura real.
+

--- a/AingZ_Platform_main/BACKUP/README.md
+++ b/AingZ_Platform_main/BACKUP/README.md
@@ -1,0 +1,36 @@
+# BACKUP — README v1
+
+> **STATUS:** `PENDIENTE`
+> **Última actualización:** 2025-08-02 | Autor: Gastón Zelechower
+
+---
+
+## 1. Resumen
+Descripción pendiente.
+
+## 2. Snapshots / Contexto
+- Carpeta de snapshots relacionada: `[./SNAPSHOTS/]`
+- Enlaces a versiones relevantes o backups IA: `[./SNAPSHOTS_CTX/]`
+
+## 3. Crossref y Mapping
+- **Referencia ascendente:** `[../]`
+- **Referencias laterales:** `[./INT/]`, `[./EXT/]`, `[./AI/]`
+- **Buckets destino típicos:** `[../PURGATORIO/]`, `[../CORE/]`
+- **Crossref central:** `[Mapa Global](../DOC/MPLN/crossref_global.md)`
+- **Flujos/Pipelines relevantes:** `[../WF/pipeline_backup.md]`, `[../PIPELINES/pipeline_backup.md]`
+
+## 4. Precedencia en el Árbol de Directorios
+```text
+AingZ_Platform_main/
+└── BACKUP/
+```
+
+## 5. Pipeline y Workflows (Ciclo de Vida)
+1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_backup.md]`
+2. **Staging / MIG:** `[../WF/wf_staging_backup.md]`
+3. **Consolidación / CORE:** `[../WF/wf_consolidacion_backup.md]`
+4. **Backup / Eliminación:** `[../WF/wf_backup_backup.md]`
+
+---
+Completar todos los campos con links activos una vez creada la estructura real.
+

--- a/AingZ_Platform_main/README_bucket_template.md
+++ b/AingZ_Platform_main/README_bucket_template.md
@@ -1,0 +1,42 @@
+# [NOMBRE_BUCKET] — README Template v1
+
+> **STATUS:** `PENDIENTE`
+> **Última actualización:** YYYY-MM-DD | Autor: <Autor>
+
+---
+
+## 1. Resumen
+Breve descripción del propósito y alcance de este bucket/carpeta. Completar según corresponda.
+
+## 2. Snapshots / Contexto
+- Carpeta de snapshots relacionada: `[./SNAPSHOTS/]` (ajustar si aplica)
+- Enlaces a versiones relevantes o backups IA: `[./SNAPSHOTS_CTX/]` (opcional)
+
+## 3. Crossref y Mapping
+- **Referencia ascendente:** `[../]`
+- **Referencias laterales:** `[./BUCKET_LATERAL1/]`, `[./BUCKET_LATERAL2/]`
+- **Buckets destino típicos:** `[../DESTINO/]`
+- **Crossref central:** `[Mapa Global](../DOC/MPLN/crossref_global.md)`
+- **Flujos/Pipelines relevantes:** `[../WF/pipeline_BUCKET.md]`, `[../PIPELINES/pipeline_BUCKET.md]`
+
+## 4. Precedencia en el Árbol de Directorios
+Indicar la ubicación exacta dentro de `AingZ_Platform_main/` usando un esquema tipo:
+
+```text
+AingZ_Platform_main/
+└── RUTA/AL/B UCKET/
+```
+
+## 5. Pipeline y Workflows (Ciclo de Vida)
+Describe los pasos clave del ciclo de vida para los archivos de este bucket:
+1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
+2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
+3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
+4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+
+---
+
+Completar todos los campos con links activos una vez creada la estructura real.
+

--- a/AingZ_Platform_main/backup/AI/README.md
+++ b/AingZ_Platform_main/backup/AI/README.md
@@ -1,7 +1,0 @@
-# [BACKUP/AI] — Crossref y Mapping
-
-- **Referencia ascendente:** [../]
-- **Referencias laterales:** (auto-link)
-- **Buckets destino típicos:** (auto-link)
-- **Crossref central:** [Mapa Global](../DOC/MPLN/crossref_global.md)
-- **Flujos/Pipelines relevantes:** [../WF/pipeline_backup_ai.md], [../PIPELINES/pipeline_backup_ai.md]

--- a/AingZ_Platform_main/backup/EXT/README.md
+++ b/AingZ_Platform_main/backup/EXT/README.md
@@ -1,7 +1,0 @@
-# [BACKUP/EXT] — Crossref y Mapping
-
-- **Referencia ascendente:** [../]
-- **Referencias laterales:** (auto-link)
-- **Buckets destino típicos:** (auto-link)
-- **Crossref central:** [Mapa Global](../DOC/MPLN/crossref_global.md)
-- **Flujos/Pipelines relevantes:** [../WF/pipeline_backup_ext.md], [../PIPELINES/pipeline_backup_ext.md]

--- a/AingZ_Platform_main/backup/INT/README.md
+++ b/AingZ_Platform_main/backup/INT/README.md
@@ -1,7 +1,0 @@
-# [BACKUP/INT] — Crossref y Mapping
-
-- **Referencia ascendente:** [../]
-- **Referencias laterales:** (auto-link)
-- **Buckets destino típicos:** (auto-link)
-- **Crossref central:** [Mapa Global](../DOC/MPLN/crossref_global.md)
-- **Flujos/Pipelines relevantes:** [../WF/pipeline_backup_int.md], [../PIPELINES/pipeline_backup_int.md]

--- a/AingZ_Platform_main/backup/README.md
+++ b/AingZ_Platform_main/backup/README.md
@@ -1,7 +1,0 @@
-# [BACKUP] � Crossref y Mapping
-
-- **Referencia ascendente:** [../]
-- **Referencias laterales:** (auto-link)
-- **Buckets destino t�picos:** (auto-link)
-- **Crossref central:** [Mapa Global](../DOC/MPLN/crossref_global.md)
-- **Flujos/Pipelines relevantes:** [../WF/pipeline_backup.md], [../PIPELINES/pipeline_backup.md]


### PR DESCRIPTION
## Summary
- rename `backup` directory to `BACKUP` for consistency
- add structured README templates for `BACKUP` and its `AI`, `EXT`, and `INT` subdirectories with crossref and pipeline placeholders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d5599c40883299ce9ad0e21eb79a7