### PR TITLE
Add stage links to backup readme

### DIFF
--- a/AingZ_Platform_main/backup/README.md
+++ b/AingZ_Platform_main/backup/README.md
@@ -42,6 +42,11 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 
 Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
 
+## 6. Etapas previas y finales
+- [CORE](../core/)
+- [BACKUP](./)
+- [BACKUP final](../BACKUP/)
+
 ---
 
 Completar todos los campos con links activos una vez creada la estructura real.


### PR DESCRIPTION
## Summary
- add references to CORE, BACKUP and final BACKUP stages in backup README

## Testing
- `pytest`
- `ls AingZ_Platform_main/core`
- `ls AingZ_Platform_main/backup`
- `ls AingZ_Platform_main/BACKUP`


------
https://chatgpt.com/codex/tasks/task_e_688e1d366ba88329bf62b7df3905dc72